### PR TITLE
Implement support to restrict probes to a specific address family

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -76,6 +76,10 @@ and check offered SASL mechanisms.
     # Configure how TLS is established. Used for both direct TLS and STARTTLS.
     [ tls_config: <tls_config> ]
 
+    # If set, only the IP protocol version given below will be used. If the
+    # XMPP service is not reachable under that version, the check will fail.
+    [ restrict_ip_version: <ip_version> ]
+
 ```
 
 ### <s2s_probe>
@@ -120,6 +124,10 @@ and check offered SASL mechanisms as well as dialback.
     # In addition, a Gauge indicating the presence of the dialback feature is
     # exported.
     [ export_auth_mechanisms: <boolean> ]
+
+    # If set, only the IP protocol version given below will be used. If the
+    # XMPP service is not reachable under that version, the check will fail.
+    [ restrict_ip_version: <ip_version> ]
 
 ```
 
@@ -185,6 +193,10 @@ delete it.
     # cause a high cardinality in these labels, so enable with care.
     [ export_error_info: <boolean> ]
 
+    # If set, only the IP protocol version given below will be used. If the
+    # XMPP service is not reachable under that version, the check will fail.
+    [ restrict_ip_version: <ip_version> ]
+
 ```
 
 ### <tls_config>
@@ -216,3 +228,7 @@ Configures an account used for in-band checks like the `<ping_probe>`.
     # The default is 15s.
     [ health_check_timeout: <duration> ]
 ```
+
+### <ip_version>
+
+A string with one of the following values: ``ipv4``, ``ipv6``.

--- a/internal/config/address_family.go
+++ b/internal/config/address_family.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+type AddressFamily string
+
+const (
+	ADDRESS_FAMILY_IPV4 AddressFamily = "ipv4"
+	ADDRESS_FAMILY_IPV6 AddressFamily = "ipv6"
+)
+
+func (af AddressFamily) Validate() error {
+	switch af {
+	case ADDRESS_FAMILY_IPV4:
+		return nil
+	case ADDRESS_FAMILY_IPV6:
+		return nil
+	case "":
+		return nil
+	default:
+		return fmt.Errorf("invalid address family: %#v", af)
+	}
+}
+
+func (af AddressFamily) MatchesNetwork(network string) bool {
+	switch af {
+	case ADDRESS_FAMILY_IPV4:
+		if strings.HasSuffix(network, "4") {
+			return true
+		}
+		return false
+	case ADDRESS_FAMILY_IPV6:
+		if strings.HasSuffix(network, "6") {
+			return true
+		}
+		return false
+	default:
+		return true
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,7 @@ type C2SProbe struct {
 	RequireSASLMechanisms []string         `yaml:"fail_if_sasl_mechanism_not_offered,omitempty"`
 	ForbidSASLMechanisms  []string         `yaml:"fail_if_sasl_mechanism_offered,omitempty"`
 	ExportSASLMechanisms  bool             `yaml:"export_sasl_mechanisms,omitempty"`
+	RestrictAddressFamily AddressFamily    `yaml:"restrict_ip_version,omitempty"`
 }
 
 type S2SProbe struct {
@@ -59,6 +60,7 @@ type S2SProbe struct {
 	ForbidDialback        bool             `yaml:"fail_if_dialback_offered,omitempty"`
 	ExportAuthMechanisms  bool             `yaml:"export_auth_mechanisms,omitempty"`
 	From                  string           `yaml:"from"`
+	RestrictAddressFamily AddressFamily    `yaml:"restrict_ip_version,omitempty"`
 }
 
 type PingResult struct {
@@ -88,10 +90,11 @@ func (r PingResult) Matches(other PingResult) bool {
 }
 
 type IBRProbe struct {
-	Prefix          string           `yaml:"prefix,omitempty"`
-	TLSConfig       config.TLSConfig `yaml:"tls_config,omitempty"`
-	DirectTLS       bool             `yaml:"directtls,omitempty"`
-	ExportErrorInfo bool             `yaml:"export_error_info,omitempty"`
+	Prefix                string           `yaml:"prefix,omitempty"`
+	TLSConfig             config.TLSConfig `yaml:"tls_config,omitempty"`
+	DirectTLS             bool             `yaml:"directtls,omitempty"`
+	ExportErrorInfo       bool             `yaml:"export_error_info,omitempty"`
+	RestrictAddressFamily AddressFamily    `yaml:"restrict_ip_version,omitempty"`
 }
 
 type Module struct {
@@ -142,6 +145,9 @@ func (s *PingProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 func (p *C2SProbe) Validate() error {
+	if err := p.RestrictAddressFamily.Validate(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -164,6 +170,10 @@ func (p *S2SProbe) Validate() error {
 		return fmt.Errorf("cannot both require and forbid dialback")
 	}
 
+	if err := p.RestrictAddressFamily.Validate(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -180,6 +190,10 @@ func (p *PingProbe) Validate(validAccounts map[string]bool) error {
 func (p *IBRProbe) Validate() error {
 	if p.Prefix == "" {
 		return fmt.Errorf("prefix must not be empty")
+	}
+
+	if err := p.RestrictAddressFamily.Validate(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/prober/c2s_tls.go
+++ b/internal/prober/c2s_tls.go
@@ -103,7 +103,7 @@ func ProbeC2S(ctx context.Context, target string, config config.Module, _ Client
 	ct.starttls = !config.C2S.DirectTLS
 	ct.start = time.Now()
 
-	tls_state_from_dial, conn, err := dialXMPP(ctx, config.C2S.DirectTLS, tls_config, host, addr, false)
+	tls_state_from_dial, conn, err := dialXMPP(ctx, config.C2S.DirectTLS, tls_config, host, addr, false, config.C2S.RestrictAddressFamily)
 	if err != nil {
 		log.Printf("failed to probe c2s to %s: %s", target, err)
 		return false

--- a/internal/prober/client.go
+++ b/internal/prober/client.go
@@ -31,7 +31,7 @@ func (cfg *ClientConfig) Login(ctx context.Context) (ct connTrace, conn net.Conn
 	ct.starttls = !cfg.DirectTLS
 	ct.start = time.Now()
 
-	_, conn, err = dialXMPP(ctx, cfg.DirectTLS, cfg.TLS, "", cfg.ClientAddress, false)
+	_, conn, err = dialXMPP(ctx, cfg.DirectTLS, cfg.TLS, "", cfg.ClientAddress, false, "")
 	if err != nil {
 		log.Printf("failed to connect to domain %s: %s", cfg.ClientAddress.Domainpart(), err)
 		return ct, nil, nil, err

--- a/internal/prober/ibr.go
+++ b/internal/prober/ibr.go
@@ -134,7 +134,7 @@ func ProbeIBR(ctx context.Context, target string, config config.Module, _ Client
 	ct.starttls = !config.IBR.DirectTLS
 	ct.start = time.Now()
 
-	_, conn, err := dialXMPP(ctx, config.IBR.DirectTLS, tls_config, host, addr, false)
+	_, conn, err := dialXMPP(ctx, config.IBR.DirectTLS, tls_config, host, addr, false, config.IBR.RestrictAddressFamily)
 	if err != nil {
 		log.Printf("failed to probe c2s to %s: %s", target, err)
 		return false

--- a/internal/prober/s2s_tls.go
+++ b/internal/prober/s2s_tls.go
@@ -125,7 +125,7 @@ func ProbeS2S(ctx context.Context, target string, config config.Module, _ Client
 	ct.starttls = !config.S2S.DirectTLS
 	ct.start = time.Now()
 
-	tls_state_from_dial, conn, err := dialXMPP(ctx, config.S2S.DirectTLS, tls_config, host, to, true)
+	tls_state_from_dial, conn, err := dialXMPP(ctx, config.S2S.DirectTLS, tls_config, host, to, true, config.S2S.RestrictAddressFamily)
 	if err != nil {
 		log.Printf("failed to probe c2s to %s: %s", target, err)
 		return false


### PR DESCRIPTION
The intent is to be able to check v4/v6 connectivity separately.
By default, all address families are allowed.