### PR TITLE
Do not log successful probes

### DIFF
--- a/cmd/xmpp_blackbox_exporter/xmpp_blackbox_exporter.go
+++ b/cmd/xmpp_blackbox_exporter/xmpp_blackbox_exporter.go
@@ -149,7 +149,6 @@ func probeHandler(w http.ResponseWriter, r *http.Request, conf *config.Config, c
 
 	if success {
 		probeSuccessGauge.Set(1)
-		log.Printf("probe succeeded")
 	} else {
 		log.Printf("probe failed")
 	}


### PR DESCRIPTION
They just spam the logs without any value.