### PR TITLE
Protect use of abort() in healthcheck()

### DIFF
--- a/internal/prober/client.go
+++ b/internal/prober/client.go
@@ -202,6 +202,8 @@ func (c *Client) healthcheck() {
 
 	if err != nil {
 		log.Printf("health check on client failed: %s", err)
+		c.sessionLock.Lock()
+		defer c.sessionLock.Unlock()
 		c.abort()
 		return
 	}


### PR DESCRIPTION
Abort must be run with the sessionLock held, otherwise unspeakably
terrible things may happen.